### PR TITLE
Correcting typo ('appearance')

### DIFF
--- a/src/groups/appearance.js
+++ b/src/groups/appearance.js
@@ -1,5 +1,5 @@
-const apperance = [
-  'apperance',
+const appearance = [
+  'appearance',
   'visibility',
   'color-scheme',
   'forced-color-adjust',
@@ -101,4 +101,4 @@ const apperance = [
   '-webkit-box-decoration-break'
 ]
 
-module.exports = { apperance }
+module.exports = { appearance }

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const { positioning } = require('./groups/positioning')
 const { layout } = require('./groups/layout')
 const { boxModel } = require('./groups/box-model')
-const { apperance } = require('./groups/apperance')
+const { appearance } = require('./groups/appearance')
 const { typography } = require('./groups/typography')
 const { interaction } = require('./groups/interaction')
 const { transition } = require('./groups/transition')
@@ -15,7 +15,7 @@ const propertyGroups = [
   layout,
   boxModel,
   typography,
-  apperance,
+  appearance,
   svgPresentation,
   transition
 ]


### PR DESCRIPTION
Small PR to correct a typo (apperance) to appearance. This would mean that the appearance property will not be sorted.