### PR TITLE
Removed duplicate 'box-decoration-break'

### DIFF
--- a/src/groups/appearance.js
+++ b/src/groups/appearance.js
@@ -29,6 +29,7 @@ const appearance = [
   'clip-path',
   'filter',
   'backdrop-filter',
+  '-webkit-box-decoration-break',
   'box-decoration-break',
   'border',
   'border-color',
@@ -96,9 +97,7 @@ const appearance = [
   'outline-offset',
   'box-shadow',
   'mix-blend-mode',
-  'caret-color',
-  'box-decoration-break',
-  '-webkit-box-decoration-break'
+  'caret-color'
 ]
 
 module.exports = { appearance }


### PR DESCRIPTION
Moved the vendor-prefixed '-webkit-box-decoration-break' needed for Safari above the upper instance and removed the duplicate lower one