### PR TITLE
fix: explicitly import stylelint-order package

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "semantic-release": "^25.0.2",
     "stylelint": "^16.26.0",
     "stylelint-order": "^7.0.0",
+    "typescript": "^5.9.3",
     "vitest": "^4.0.13"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       stylelint-order:
         specifier: ^7.0.0
         version: 7.0.0(stylelint@16.26.0(typescript@5.9.3))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^4.0.13
         version: 4.0.13(@types/node@24.10.1)(jiti@2.6.1)(yaml@2.8.1)

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import order from 'stylelint-order'
+
 import { appearance } from './groups/appearance.ts'
 import { boxModel } from './groups/box-model.ts'
 import { interaction } from './groups/interaction.ts'
@@ -31,7 +33,7 @@ const EMPTY_LINE_MINIMUM_PROPERTY_THRESHOLD = 5
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Let return type be inferred.
 export function getConfig({ severity }: { severity: 'error' | 'warning' }) {
   return {
-    plugins: ['stylelint-order'],
+    plugins: [order],
     rules: {
       'declaration-empty-line-before': [
         'always',

--- a/src/stylelint-order.d.ts
+++ b/src/stylelint-order.d.ts
@@ -1,0 +1,6 @@
+declare module 'stylelint-order' {
+  import type { Plugin } from 'stylelint'
+
+  const plugin: Plugin
+  export default plugin
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,5 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@kutsan/typescript-config/node.json",
-  "compilerOptions": {
-    "skipLibCheck": true
-  },
   "include": ["**/*.ts", "**/*.js"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "@kutsan/typescript-config/node.json",
+  "compilerOptions": {
+    "skipLibCheck": true
+  },
   "include": ["**/*.ts", "**/*.js"]
 }


### PR DESCRIPTION
Thanks for a super useful package! Currently, using this config fails in Deno because stylelint looks for plugins referenced by string names in `node_modules/`, which isn't created by default in Deno.

Explicitly importing `stylelint-order` instead of referencing it by name fixes this in Deno.

## Testing

Install `deno`, create this `deno.json` file, and run `deno task stylelint` it to see the error:

```json
{
  "tasks": {
    "stylelint": "deno run --allow-all stylelint src/**/*.css"
  },
  "imports": {
    "stylelint": "npm:stylelint@^17.1.1",
    "stylelint-config-clean-order": "npm:stylelint-config-clean-order@^8.0.0",
    "stylelint-order": "npm:stylelint-order@^7.0.1"
  }
}
```

Then change it to the following and run `deno task stylelint` to verify the fix:

```json
{
  "tasks": {
    "stylelint": "deno run --allow-all stylelint src/**/*.css"
  },
  "imports": {
    "stylelint": "npm:stylelint@^17.1.1",
    "stylelint-config-clean-order": "https://raw.githubusercontent.com/canac/stylelint-config-clean-order/import-order-plugin/src/index.ts",
    "stylelint-order": "npm:stylelint-order@^7.0.1"
  }
}
```