### PR TITLE
fix: add missing `text-autospace` property

### DIFF
--- a/src/groups/typography.ts
+++ b/src/groups/typography.ts
@@ -31,6 +31,7 @@ export const typography: Array<keyof CSS.StandardPropertiesHyphen> = [
   'color',
   'text-align',
   'text-align-last',
+  'text-autospace',
   'text-emphasis',
   'text-emphasis-color',
   'text-emphasis-style',


### PR DESCRIPTION
Just adding support for the [text-autospace](https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Properties/text-autospace) property.