### PR TITLE
Add package support metadata

### DIFF
--- a/.changeset/support-metadata.md
+++ b/.changeset/support-metadata.md
@@ -1,0 +1,5 @@
+---
+"stylelint-config-clean-order": patch
+---
+
+Add npm homepage and bugs metadata.

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "type": "git",
     "url": "git+https://github.com/kutsan/stylelint-config-clean-order.git"
   },
+    "homepage": "https://github.com/kutsan/stylelint-config-clean-order#readme",
+  "bugs": {
+    "url": "https://github.com/kutsan/stylelint-config-clean-order/issues"
+  },
   "license": "MIT",
   "author": "Kutsan Kaplan <me@kutsan.dev> (https://kutsan.dev)",
   "type": "module",


### PR DESCRIPTION
Adds the missing npm support metadata for the package:

- `homepage` points to the repository README
- `bugs.url` points to the repository issue tracker

This lets npm show the package homepage and issue-reporting link directly from the published package metadata.

Validation:

```sh
node -e "const p=require('./package.json'); if(!p.homepage) process.exit(1); if(!p.bugs?.url) process.exit(2)"
git diff --check